### PR TITLE
[feedbackd] Support multiple droid backends, add support for AIDL HALs

### DIFF
--- a/src/fbd-binder.c
+++ b/src/fbd-binder.c
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2022 Eugenio "g7" Paolantonio
+ * Copyright (C) 2021 Erfan Abdi
+ * SPDX-License-Identifier: GPL-3.0+
+ * Author: Eugenio "g7" Paolantonio <me@medesimo.eu>
+ *         Erfan Abdi
+ */
+
+#define G_LOG_DOMAIN "fbd-binder"
+
+#include "fbd-binder.h"
+
+#include <gio/gio.h>
+
+#include <errno.h>
+
+gboolean
+fbd_binder_status_is_ok (GBinderReader *reader)
+{
+  int status;
+
+  if (gbinder_reader_read_int32 (reader, &status) && status == 0) {
+    return TRUE;
+  }
+
+  return FALSE;
+}
+
+gboolean
+fbd_binder_reply_status_is_ok (GBinderRemoteReply *reply)
+{
+  GBinderReader reader;
+  
+  gbinder_remote_reply_init_reader (reply, &reader);
+  
+  return fbd_binder_status_is_ok (&reader);
+}
+
+gboolean
+fbd_binder_init (char                   *device,
+                 char                   *iface,
+                 char                   *fqname,
+                 GBinderServiceManager **service_manager,
+                 GBinderRemoteObject   **remote,
+                 GBinderClient         **client)
+{
+
+
+  *service_manager = gbinder_servicemanager_new (device);
+  if (!*service_manager) {
+    g_warning ("Failed to init servicemanager on %s", device);
+    return FALSE;
+  }
+  
+  *remote = gbinder_servicemanager_get_service_sync (*service_manager,
+                                                     fqname, NULL);
+  if (!*remote) {
+    g_warning ("Failed to get hal service remote for %s", fqname);
+    g_clear_object (&*service_manager);
+    *service_manager = NULL;
+    return FALSE;
+  }
+  
+  *client = gbinder_client_new (*remote, iface);
+  if (!*client) {
+    g_warning ("Failed to get hal service client for %s", iface);
+    g_clear_object (&*remote);
+    g_clear_object (&*service_manager);
+    return FALSE;
+  }
+
+  /* Ensure we keep a reference on the remote */
+  gbinder_remote_object_ref (*remote);
+
+  return TRUE;
+}

--- a/src/fbd-binder.h
+++ b/src/fbd-binder.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2022 Eugenio "g7" Paolantonio
+ * SPDX-License-Identifier: GPL-3.0+
+ * Author: Eugenio "g7" Paolantonio <me@medesimo.eu>
+ */
+
+#pragma once
+
+#include <glib.h>
+#include <gbinder.h>
+
+G_BEGIN_DECLS
+
+/* Source: https://android.googlesource.com/platform/frameworks/native/+/master/libs/binder/include/binder/Stability.h */
+enum BinderStability {
+  BINDER_STABILITY_UNDECLARED = 0,
+  
+  BINDER_STABILITY_VENDOR = 0b000011,
+  BINDER_STABILITY_SYSTEM = 0b001100,
+  BINDER_STABILITY_VINTF  = 0b111111,
+};
+
+gboolean fbd_binder_init (char                   *device,
+                          char                   *iface,
+                          char                   *fqname,
+                          GBinderServiceManager **service_manager,
+                          GBinderRemoteObject   **remote,
+                          GBinderClient         **client);
+gboolean fbd_binder_status_is_ok (GBinderReader *reader);
+gboolean fbd_binder_reply_status_is_ok (GBinderRemoteReply *reply);
+
+G_END_DECLS

--- a/src/fbd-droid-leds-backend-aidl.c
+++ b/src/fbd-droid-leds-backend-aidl.c
@@ -1,0 +1,261 @@
+/*
+ * Copyright (C) 2022 Eugenio "g7" Paolantonio
+ * SPDX-License-Identifier: GPL-3.0+
+ * Author: Eugenio "g7" Paolantonio <me@medesimo.eu>
+ */
+
+#define G_LOG_DOMAIN "fbd-droid-leds-backend-aidl"
+
+#include <stdlib.h>
+#include <glib.h>
+#include <glib-object.h>
+#include <gio/gio.h>
+#include <gbinder.h>
+
+#include "fbd-binder.h"
+#include "fbd-droid-leds-backend.h"
+#include "fbd-droid-leds-backend-aidl.h"
+
+#define BINDER_LIGHT_DEFAULT_AIDL_DEVICE "/dev/binder"
+
+#define BINDER_LIGHT_AIDL_IFACE "android.hardware.light.ILights"
+#define BINDER_LIGHT_AIDL_SLOT "default"
+
+/* Methods */
+enum
+{
+  /* void setLightState(in int id, in android.hardware.light.HwLightState state); */
+  BINDER_LIGHT_AIDL_SET_LIGHT_STATE = 1,
+  /* android.hardware.light.HwLight[] getLights(); */
+  BINDER_LIGHT_AIDL_GET_LIGHTS = 2,
+};
+
+struct _FbdDroidLedsBackendAidl
+{
+  GObject parent_instance;
+
+  GBinderServiceManager *service_manager;
+  GBinderRemoteObject   *remote;
+  GBinderClient         *client;
+};
+
+static void initable_interface_init (GInitableIface *iface);
+static void fbd_droid_leds_backend_interface_init (FbdDroidLedsBackendInterface *iface);
+
+G_DEFINE_TYPE_WITH_CODE (FbdDroidLedsBackendAidl, fbd_droid_leds_backend_aidl, G_TYPE_OBJECT,
+                         G_IMPLEMENT_INTERFACE (G_TYPE_INITABLE, initable_interface_init)
+                         G_IMPLEMENT_INTERFACE (FBD_TYPE_DROID_LEDS_BACKEND,
+                                                fbd_droid_leds_backend_interface_init))
+
+static gboolean
+fbd_droid_leds_backend_aidl_is_supported (FbdDroidLedsBackend *backend)
+{
+  FbdDroidLedsBackendAidl *self = FBD_DROID_LEDS_BACKEND_AIDL (backend);
+  GBinderLocalRequest *req = gbinder_client_new_request (self->client);
+  GBinderRemoteReply *reply;
+  GBinderReader reader;
+  int status;
+  int count = 0;
+  AidlHwLight *light;
+
+  reply = gbinder_client_transact_sync_reply (self->client,
+                                              BINDER_LIGHT_AIDL_GET_LIGHTS,
+                                              req, &status);
+  gbinder_local_request_unref (req);
+
+  gbinder_remote_reply_init_reader (reply, &reader);
+
+  if (status == GBINDER_STATUS_OK && fbd_binder_status_is_ok (&reader)) {
+    gbinder_reader_read_int32 (&reader, &count); /* led count */
+
+    for (int i=0; i < count; i++) {
+      light = (AidlHwLight *)gbinder_reader_read_parcelable (&reader, NULL);
+      if (light->type == LIGHT_TYPE_NOTIFICATIONS) {
+        g_debug ("droid LED usable");
+        return TRUE;
+      }
+    }
+
+    g_warning ("No suitable notification LED found");
+  } else {
+    g_warning ("Failed to get supported LED types");
+  }
+
+  return FALSE;
+}
+
+static gboolean
+fbd_droid_leds_backend_aidl_start_periodic (FbdDroidLedsBackend *backend,
+                                            FbdFeedbackLedColor color,
+                                            guint               max_brightness,
+                                            guint               freq)
+{
+  FbdDroidLedsBackendAidl *self = FBD_DROID_LEDS_BACKEND_AIDL (backend);
+  GBinderLocalRequest *req = gbinder_client_new_request (self->client);
+  GBinderRemoteReply *reply;
+  GBinderWriter writer;
+  LightState* notification_state;
+  int32_t status, argb_color, t;
+
+  argb_color = fbd_droid_leds_backend_get_argb_color (color, max_brightness);
+  t = 1000 * 1000 / freq / 2;
+
+  gbinder_local_request_init_writer (req, &writer);
+  notification_state = gbinder_writer_new0 (&writer, LightState);
+  notification_state->color = argb_color;
+  notification_state->flashMode = FLASH_TYPE_TIMED;
+  notification_state->flashOnMs = t;
+  notification_state->flashOffMs = t;
+  notification_state->brightnessMode = BRIGHTNESS_MODE_USER;
+
+  gbinder_writer_append_int32 (&writer, LIGHT_TYPE_NOTIFICATIONS);
+  gbinder_writer_append_parcelable (&writer, notification_state, sizeof(*notification_state));
+  gbinder_writer_append_int32 (&writer, BINDER_STABILITY_VINTF); /* stability */
+
+  reply = gbinder_client_transact_sync_reply (self->client,
+                                              BINDER_LIGHT_AIDL_SET_LIGHT_STATE,
+                                              req, &status);
+  gbinder_local_request_unref (req);
+  
+  if (status == GBINDER_STATUS_OK && fbd_binder_reply_status_is_ok (reply)) {
+    return TRUE;
+  } else {
+    g_warning ("Unable to turn to set notification LED");
+    return FALSE;
+  }
+}
+
+static gboolean
+fbd_droid_leds_backend_aidl_stop (FbdDroidLedsBackend *backend,
+                                  FbdFeedbackLedColor  color)
+{
+  FbdDroidLedsBackendAidl *self = FBD_DROID_LEDS_BACKEND_AIDL (backend);
+  GBinderLocalRequest *req = gbinder_client_new_request (self->client);
+  GBinderRemoteReply *reply;
+  GBinderWriter writer;
+  LightState* notification_state;
+  int status;
+
+  gbinder_local_request_init_writer (req, &writer);
+  notification_state = gbinder_writer_new0 (&writer, LightState);
+  notification_state->color = 0;
+  notification_state->flashMode = FLASH_TYPE_NONE;
+  notification_state->flashOnMs = 0;
+  notification_state->flashOffMs = 0;
+  notification_state->brightnessMode = BRIGHTNESS_MODE_USER;
+
+  gbinder_writer_append_int32 (&writer, LIGHT_TYPE_NOTIFICATIONS);
+  gbinder_writer_append_parcelable (&writer, notification_state, sizeof(*notification_state));
+  gbinder_writer_append_int32 (&writer, BINDER_STABILITY_VINTF); /* stability */
+
+  reply = gbinder_client_transact_sync_reply (self->client,
+                                              BINDER_LIGHT_AIDL_SET_LIGHT_STATE,
+                                              req, &status);
+  gbinder_local_request_unref (req);
+  
+  if (status == GBINDER_STATUS_OK && fbd_binder_reply_status_is_ok (reply)) {
+    return TRUE;
+  } else {
+    g_warning ("Unable to stop notification LED");
+    return FALSE;
+  }
+}
+
+static gboolean
+initable_init (GInitable     *initable,
+               GCancellable  *cancellable,
+               GError       **error)
+{
+  FbdDroidLedsBackendAidl *self = FBD_DROID_LEDS_BACKEND_AIDL (initable);
+  gboolean success;
+
+  g_debug ("Initializing droid leds aidl");
+
+  success = fbd_binder_init (BINDER_LIGHT_DEFAULT_AIDL_DEVICE,
+                             BINDER_LIGHT_AIDL_IFACE,
+                             (BINDER_LIGHT_AIDL_IFACE "/" BINDER_LIGHT_AIDL_SLOT),
+                             &self->service_manager,
+                             &self->remote,
+                             &self->client);
+
+  if (!success) {
+    g_set_error (error,
+                 G_IO_ERROR, G_IO_ERROR_FAILED,
+                 "Failed to obtain suitable light hal");
+    return FALSE;
+  }
+
+  return TRUE;
+}
+
+static void
+fbd_droid_leds_backend_aidl_constructed (GObject *obj)
+{
+  FbdDroidLedsBackendAidl *self = FBD_DROID_LEDS_BACKEND_AIDL (obj);
+
+  G_OBJECT_CLASS (fbd_droid_leds_backend_aidl_parent_class)->constructed (obj);
+
+  self->service_manager = NULL;
+  self->remote = NULL;
+  self->client = NULL;
+}
+
+static void
+fbd_droid_leds_backend_aidl_dispose (GObject *obj)
+{
+  FbdDroidLedsBackendAidl *self = FBD_DROID_LEDS_BACKEND_AIDL (obj);
+
+  g_debug ("Disposing droid leds aidl");
+
+  if (self->client) {
+    gbinder_client_unref (self->client);
+  }
+  
+  if (self->remote) {
+    gbinder_remote_object_unref (self->remote);
+  }
+  
+  if (self->service_manager) {
+    gbinder_servicemanager_unref (self->service_manager);
+  }
+
+  G_OBJECT_CLASS (fbd_droid_leds_backend_aidl_parent_class)->dispose (obj);
+}
+
+static void
+fbd_droid_leds_backend_aidl_class_init (FbdDroidLedsBackendAidlClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+  object_class->constructed  = fbd_droid_leds_backend_aidl_constructed;
+  object_class->dispose      = fbd_droid_leds_backend_aidl_dispose;
+}
+
+static void
+initable_interface_init (GInitableIface *iface)
+{
+  iface->init = initable_init;
+}
+
+static void
+fbd_droid_leds_backend_interface_init (FbdDroidLedsBackendInterface *iface)
+{
+  iface->is_supported    = fbd_droid_leds_backend_aidl_is_supported;
+  iface->start_periodic  = fbd_droid_leds_backend_aidl_start_periodic;
+  iface->stop            = fbd_droid_leds_backend_aidl_stop;
+}
+
+static void
+fbd_droid_leds_backend_aidl_init (FbdDroidLedsBackendAidl *self)
+{
+}
+
+FbdDroidLedsBackendAidl *
+fbd_droid_leds_backend_aidl_new (GError **error)
+{
+  return FBD_DROID_LEDS_BACKEND_AIDL (
+    g_initable_new (FBD_TYPE_DROID_LEDS_BACKEND_AIDL,
+                    NULL,
+                    error,
+                    NULL));
+}

--- a/src/fbd-droid-leds-backend-aidl.h
+++ b/src/fbd-droid-leds-backend-aidl.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2022 Eugenio "g7" Paolantonio
+ * SPDX-License-Identifier: GPL-3.0+
+ * Author: Eugenio "g7" Paolantonio <me@medesimo.eu>
+ */
+
+#pragma once
+
+#include <glib-object.h>
+#include <stdint.h>
+
+#include "fbd-droid-leds-backend.h"
+
+G_BEGIN_DECLS
+
+#define ALIGNED(x) __attribute__ ((aligned(x)))
+
+#define FBD_TYPE_DROID_LEDS_BACKEND_AIDL fbd_droid_leds_backend_aidl_get_type ()
+G_DECLARE_FINAL_TYPE (FbdDroidLedsBackendAidl, fbd_droid_leds_backend_aidl, FBD, DROID_LEDS_BACKEND_AIDL, GObject)
+
+typedef struct aidl_hw_light {
+  int32_t id;
+  int32_t ordinal;
+  LightType type ALIGNED(4);
+} AidlHwLight;
+
+FbdDroidLedsBackendAidl *fbd_droid_leds_backend_aidl_new (GError **error);
+
+G_END_DECLS

--- a/src/fbd-droid-leds-backend-hidl.c
+++ b/src/fbd-droid-leds-backend-hidl.c
@@ -1,0 +1,262 @@
+/*
+ * Copyright (C) 2021 Erfan Abdi
+ * Copyright (C) 2022 Eugenio "g7" Paolantonio
+ * SPDX-License-Identifier: GPL-3.0+
+ * Author: Erfan Abdi
+ *         Eugenio "g7" Paolantonio <me@medesimo.eu>
+ */
+
+#define G_LOG_DOMAIN "fbd-droid-leds-backend-hidl"
+
+#include <stdlib.h>
+#include <glib.h>
+#include <glib-object.h>
+#include <gio/gio.h>
+#include <gbinder.h>
+
+#include "fbd-binder.h"
+#include "fbd-droid-leds-backend.h"
+#include "fbd-droid-leds-backend-hidl.h"
+
+#define BINDER_LIGHT_DEFAULT_HIDL_DEVICE "/dev/hwbinder"
+
+#define BINDER_LIGHT_HIDL_IFACE(v) "android.hardware.light@" v "::ILight"
+#define BINDER_LIGHT_HIDL_SLOT "default"
+
+#define BINDER_LIGHT_HIDL_2_0_IFACE BINDER_LIGHT_HIDL_IFACE("2.0")
+
+/* Methods */
+enum
+{
+  /* setLight(Type type, LightState state) generates (Status status); */
+  BINDER_LIGHT_HIDL_2_0_SET_LIGHT = 1,
+  /* getSupportedTypes() generates (vec<Type> types); */
+  BINDER_LIGHT_HIDL_2_0_GET_SUPPORTED_TYPES = 2,
+};
+
+struct _FbdDroidLedsBackendHidl
+{
+  GObject parent_instance;
+
+  GBinderServiceManager *service_manager;
+  GBinderRemoteObject   *remote;
+  GBinderClient         *client;
+};
+
+static void initable_interface_init (GInitableIface *iface);
+static void fbd_droid_leds_backend_interface_init (FbdDroidLedsBackendInterface *iface);
+
+G_DEFINE_TYPE_WITH_CODE (FbdDroidLedsBackendHidl, fbd_droid_leds_backend_hidl, G_TYPE_OBJECT,
+                         G_IMPLEMENT_INTERFACE (G_TYPE_INITABLE, initable_interface_init)
+                         G_IMPLEMENT_INTERFACE (FBD_TYPE_DROID_LEDS_BACKEND,
+                                                fbd_droid_leds_backend_interface_init))
+
+static gboolean
+fbd_droid_leds_backend_hidl_is_supported (FbdDroidLedsBackend *backend)
+{
+  FbdDroidLedsBackendHidl *self = FBD_DROID_LEDS_BACKEND_HIDL (backend);
+  GBinderLocalRequest *req = gbinder_client_new_request (self->client);
+  GBinderRemoteReply *reply;
+  GBinderReader reader;
+  int status;
+  gsize count = 0, vecSize = 0;
+  const int32_t *types;
+
+  reply = gbinder_client_transact_sync_reply (self->client,
+                                              BINDER_LIGHT_HIDL_2_0_GET_SUPPORTED_TYPES,
+                                              req, &status);
+  gbinder_local_request_unref (req);
+
+  gbinder_remote_reply_init_reader (reply, &reader);
+
+  if (status == GBINDER_STATUS_OK && fbd_binder_status_is_ok (&reader)) {
+    types = gbinder_reader_read_hidl_vec(&reader, &count, &vecSize);
+    for (int i = 0; i < count; i++) {
+        if (types[i] == LIGHT_TYPE_NOTIFICATIONS) {
+            g_debug ("droid LED usable");
+            return TRUE;
+        }
+    }
+    g_warning ("No suitable notification LED found");
+  } else {
+    g_warning ("Failed to get supported LED types");
+  }
+
+  return FALSE;
+}
+
+static gboolean
+fbd_droid_leds_backend_hidl_start_periodic (FbdDroidLedsBackend *backend,
+                                            FbdFeedbackLedColor color,
+                                            guint               max_brightness,
+                                            guint               freq)
+{
+  FbdDroidLedsBackendHidl *self = FBD_DROID_LEDS_BACKEND_HIDL (backend);
+  GBinderLocalRequest *req = gbinder_client_new_request (self->client);
+  GBinderRemoteReply *reply;
+  GBinderWriter writer;
+  LightState* notification_state;
+  int32_t status, argb_color, t;
+
+  argb_color = fbd_droid_leds_backend_get_argb_color (color, max_brightness);
+  t = 1000 * 1000 / freq / 2;
+
+  gbinder_local_request_init_writer (req, &writer);
+  notification_state = gbinder_writer_new0 (&writer, LightState);
+  notification_state->color = argb_color;
+  notification_state->flashMode = FLASH_TYPE_TIMED;
+  notification_state->flashOnMs = t;
+  notification_state->flashOffMs = t;
+  notification_state->brightnessMode = BRIGHTNESS_MODE_USER;
+
+  gbinder_writer_append_int32 (&writer, LIGHT_TYPE_NOTIFICATIONS);
+  gbinder_writer_append_buffer_object (&writer, notification_state,
+    sizeof(*notification_state));
+
+  reply = gbinder_client_transact_sync_reply (self->client,
+                                              BINDER_LIGHT_HIDL_2_0_SET_LIGHT,
+                                              req, &status);
+  gbinder_local_request_unref (req);
+  
+  if (status == GBINDER_STATUS_OK && fbd_binder_reply_status_is_ok (reply)) {
+    return TRUE;
+  } else {
+    g_warning ("Unable to turn to set notification LED");
+    return FALSE;
+  }
+}
+
+static gboolean
+fbd_droid_leds_backend_hidl_stop (FbdDroidLedsBackend *backend,
+                                  FbdFeedbackLedColor  color)
+{
+  FbdDroidLedsBackendHidl *self = FBD_DROID_LEDS_BACKEND_HIDL (backend);
+  GBinderLocalRequest *req = gbinder_client_new_request (self->client);
+  GBinderRemoteReply *reply;
+  GBinderWriter writer;
+  LightState* notification_state;
+  int status;
+
+  gbinder_local_request_init_writer (req, &writer);
+  notification_state = gbinder_writer_new0 (&writer, LightState);
+  notification_state->color = 0;
+  notification_state->flashMode = FLASH_TYPE_NONE;
+  notification_state->flashOnMs = 0;
+  notification_state->flashOffMs = 0;
+  notification_state->brightnessMode = BRIGHTNESS_MODE_USER;
+
+  gbinder_writer_append_int32 (&writer, LIGHT_TYPE_NOTIFICATIONS);
+  gbinder_writer_append_buffer_object (&writer, notification_state,
+    sizeof(*notification_state));
+
+  reply = gbinder_client_transact_sync_reply (self->client,
+                                              BINDER_LIGHT_HIDL_2_0_SET_LIGHT,
+                                              req, &status);
+  gbinder_local_request_unref (req);
+  
+  if (status == GBINDER_STATUS_OK && fbd_binder_reply_status_is_ok (reply)) {
+    return TRUE;
+  } else {
+    g_warning ("Unable to stop notification LED");
+    return FALSE;
+  }
+}
+
+static gboolean
+initable_init (GInitable     *initable,
+               GCancellable  *cancellable,
+               GError       **error)
+{
+  FbdDroidLedsBackendHidl *self = FBD_DROID_LEDS_BACKEND_HIDL (initable);
+  gboolean success;
+
+  g_debug ("Initializing droid leds hidl");
+
+  success = fbd_binder_init (BINDER_LIGHT_DEFAULT_HIDL_DEVICE,
+                             BINDER_LIGHT_HIDL_2_0_IFACE,
+                             (BINDER_LIGHT_HIDL_2_0_IFACE "/" BINDER_LIGHT_HIDL_SLOT),
+                             &self->service_manager,
+                             &self->remote,
+                             &self->client);
+
+  if (!success) {
+    g_set_error (error,
+                 G_IO_ERROR, G_IO_ERROR_FAILED,
+                 "Failed to obtain suitable light hal");
+    return FALSE;
+  }
+
+  return TRUE;
+}
+
+static void
+fbd_droid_leds_backend_hidl_constructed (GObject *obj)
+{
+  FbdDroidLedsBackendHidl *self = FBD_DROID_LEDS_BACKEND_HIDL (obj);
+
+  G_OBJECT_CLASS (fbd_droid_leds_backend_hidl_parent_class)->constructed (obj);
+
+  self->service_manager = NULL;
+  self->remote = NULL;
+  self->client = NULL;
+}
+
+static void
+fbd_droid_leds_backend_hidl_dispose (GObject *obj)
+{
+  FbdDroidLedsBackendHidl *self = FBD_DROID_LEDS_BACKEND_HIDL (obj);
+
+  g_debug ("Disposing droid leds hidl");
+
+  if (self->client) {
+    gbinder_client_unref (self->client);
+  }
+  
+  if (self->remote) {
+    gbinder_remote_object_unref (self->remote);
+  }
+  
+  if (self->service_manager) {
+    gbinder_servicemanager_unref (self->service_manager);
+  }
+
+  G_OBJECT_CLASS (fbd_droid_leds_backend_hidl_parent_class)->dispose (obj);
+}
+
+static void
+fbd_droid_leds_backend_hidl_class_init (FbdDroidLedsBackendHidlClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+  object_class->constructed  = fbd_droid_leds_backend_hidl_constructed;
+  object_class->dispose      = fbd_droid_leds_backend_hidl_dispose;
+}
+
+static void
+initable_interface_init (GInitableIface *iface)
+{
+  iface->init = initable_init;
+}
+
+static void
+fbd_droid_leds_backend_interface_init (FbdDroidLedsBackendInterface *iface)
+{
+  iface->is_supported    = fbd_droid_leds_backend_hidl_is_supported;
+  iface->start_periodic  = fbd_droid_leds_backend_hidl_start_periodic;
+  iface->stop            = fbd_droid_leds_backend_hidl_stop;
+}
+
+static void
+fbd_droid_leds_backend_hidl_init (FbdDroidLedsBackendHidl *self)
+{
+}
+
+FbdDroidLedsBackendHidl *
+fbd_droid_leds_backend_hidl_new (GError **error)
+{
+  return FBD_DROID_LEDS_BACKEND_HIDL (
+    g_initable_new (FBD_TYPE_DROID_LEDS_BACKEND_HIDL,
+                    NULL,
+                    error,
+                    NULL));
+}

--- a/src/fbd-droid-leds-backend-hidl.h
+++ b/src/fbd-droid-leds-backend-hidl.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2022 Eugenio "g7" Paolantonio
+ * SPDX-License-Identifier: GPL-3.0+
+ * Author: Eugenio "g7" Paolantonio <me@medesimo.eu>
+ */
+
+#pragma once
+
+#include <glib-object.h>
+
+G_BEGIN_DECLS
+
+#define FBD_TYPE_DROID_LEDS_BACKEND_HIDL fbd_droid_leds_backend_hidl_get_type ()
+G_DECLARE_FINAL_TYPE (FbdDroidLedsBackendHidl, fbd_droid_leds_backend_hidl, FBD, DROID_LEDS_BACKEND_HIDL, GObject)
+
+FbdDroidLedsBackendHidl *fbd_droid_leds_backend_hidl_new (GError **error);
+
+G_END_DECLS

--- a/src/fbd-droid-leds-backend.c
+++ b/src/fbd-droid-leds-backend.c
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2022 Eugenio "g7" Paolantonio
+ * Copyright (C) 2021 Erfan Abdi
+ * SPDX-License-Identifier: GPL-3.0+
+ * Author: Eugenio "g7" Paolantonio <me@medesimo.eu>
+ *         Erfan Abdi
+ */
+
+#define G_LOG_DOMAIN "fbd-droid-leds-backend"
+
+#include "fbd-droid-leds-backend.h"
+
+G_DEFINE_INTERFACE (FbdDroidLedsBackend, fbd_droid_leds_backend, G_TYPE_OBJECT)
+
+static void
+fbd_droid_leds_backend_default_init (FbdDroidLedsBackendInterface *iface)
+{
+    /* Nothing yet */
+}
+
+int32_t
+fbd_droid_leds_backend_get_argb_color (FbdFeedbackLedColor color,
+                                       guint               max_brightness)
+{
+  int32_t alpha, max, argb_color;
+
+  max = (max_brightness / 100.0) * 0xff;
+  alpha = 0xff; // Full Alpha
+
+  argb_color = (alpha & 0xff) << 24;
+  switch (color) {
+      case FBD_FEEDBACK_LED_COLOR_WHITE:
+          argb_color += ((max & 0xff) << 16) + ((max & 0xff) << 8) + (max & 0xff);
+          break;
+      case FBD_FEEDBACK_LED_COLOR_RED:
+          argb_color += (max & 0xff) << 16;
+          break;
+      case FBD_FEEDBACK_LED_COLOR_GREEN:
+          argb_color += (max & 0xff) << 8;
+          break;
+      case FBD_FEEDBACK_LED_COLOR_BLUE:
+          argb_color += max & 0xff;
+          break;
+  }
+
+  return argb_color;
+}
+
+gboolean
+fbd_droid_leds_backend_is_supported (FbdDroidLedsBackend *self)
+{
+  FbdDroidLedsBackendInterface *iface;
+  
+  g_return_val_if_fail (FBD_IS_DROID_LEDS_BACKEND (self), FALSE);
+  
+  iface = FBD_DROID_LEDS_BACKEND_GET_IFACE (self);
+  g_return_val_if_fail (iface->is_supported != NULL, FALSE);
+  return iface->is_supported (self);
+}
+
+gboolean
+fbd_droid_leds_backend_start_periodic (FbdDroidLedsBackend *self,
+                                       FbdFeedbackLedColor color,
+                                       guint               max_brightness,
+                                       guint               freq)
+{
+  FbdDroidLedsBackendInterface *iface;
+  
+  g_return_val_if_fail (FBD_IS_DROID_LEDS_BACKEND (self), FALSE);
+  
+  iface = FBD_DROID_LEDS_BACKEND_GET_IFACE (self);
+  g_return_val_if_fail (iface->start_periodic != NULL, FALSE);
+  return iface->start_periodic (self, color, max_brightness, freq);
+}
+
+gboolean
+fbd_droid_leds_backend_stop (FbdDroidLedsBackend *self,
+                            FbdFeedbackLedColor color)
+{
+  FbdDroidLedsBackendInterface *iface;
+  
+  g_return_val_if_fail (FBD_IS_DROID_LEDS_BACKEND (self), FALSE);
+  
+  iface = FBD_DROID_LEDS_BACKEND_GET_IFACE (self);
+  g_return_val_if_fail (iface->stop != NULL, FALSE);
+  return iface->stop (self, color);
+}

--- a/src/fbd-droid-leds-backend.h
+++ b/src/fbd-droid-leds-backend.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2022 Eugenio "g7" Paolantonio
+ * SPDX-License-Identifier: GPL-3.0+
+ * Author: Eugenio "g7" Paolantonio <me@medesimo.eu>
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include <glib-object.h>
+
+#include "fbd-feedback-led.h"
+
+G_BEGIN_DECLS
+
+#define ALIGNED(x) __attribute__ ((aligned(x)))
+
+#define FBD_TYPE_DROID_LEDS_BACKEND fbd_droid_leds_backend_get_type()
+G_DECLARE_INTERFACE (FbdDroidLedsBackend, fbd_droid_leds_backend, FBD, DROID_LEDS_BACKEND, GObject)
+
+/* Light types */
+typedef enum light_type {
+  LIGHT_TYPE_BACKLIGHT = 0,
+  LIGHT_TYPE_KEYBOARD = 1,
+  LIGHT_TYPE_BUTTONS = 2,
+  LIGHT_TYPE_BATTERY = 3,
+  LIGHT_TYPE_NOTIFICATIONS = 4,
+  LIGHT_TYPE_ATTENTION = 5,
+  LIGHT_TYPE_BLUETOOTH = 6,
+  LIGHT_TYPE_WIFI = 7,
+  LIGHT_TYPE_COUNT = 8,
+} LightType;
+
+/* Flash types */
+typedef enum flash_type {
+  FLASH_TYPE_NONE = 0,
+  FLASH_TYPE_TIMED = 1,
+  FLASH_TYPE_HARDWARE = 2,
+} FlashType;
+
+/* Brightness types */
+typedef enum brightness_type {
+  BRIGHTNESS_MODE_USER = 0,
+  BRIGHTNESS_MODE_SENSOR = 1,
+  BRIGHTNESS_MODE_LOW_PERSISTENCE = 2,
+} BrightnessType;
+
+/* The light state */
+typedef struct light_state {
+  uint32_t color;
+  FlashType flashMode ALIGNED(4);
+  int32_t flashOnMs;
+  int32_t flashOffMs;
+  BrightnessType brightnessMode ALIGNED(4);
+} LightState;
+G_STATIC_ASSERT(sizeof(LightState) == 20);
+
+struct _FbdDroidLedsBackendInterface
+{
+  GTypeInterface parent_iface;
+
+  gboolean (*is_supported) (FbdDroidLedsBackend *self);
+  gboolean (*start_periodic) (FbdDroidLedsBackend *self,
+                              FbdFeedbackLedColor color,
+                              guint               max_brightness,
+                              guint               freq);
+  gboolean (*stop) (FbdDroidLedsBackend *self,
+                    FbdFeedbackLedColor color);
+};
+
+int32_t fbd_droid_leds_backend_get_argb_color (FbdFeedbackLedColor color,
+                                               guint               max_brightness);
+gboolean fbd_droid_leds_backend_is_supported (FbdDroidLedsBackend *self);
+gboolean fbd_droid_leds_backend_start_periodic (FbdDroidLedsBackend *self,
+                                                FbdFeedbackLedColor color,
+                                                guint               max_brightness,
+                                                guint               freq);
+gboolean fbd_droid_leds_backend_stop (FbdDroidLedsBackend  *self,
+                                      FbdFeedbackLedColor color);
+
+G_END_DECLS

--- a/src/fbd-droid-leds.c
+++ b/src/fbd-droid-leds.c
@@ -1,21 +1,25 @@
 /*
  * Copyright (C) 2021 Giuseppe Corti
+ * Copyright (C) 2021 Erfan Abdi
+ * Copyright (C) 2022 Eugenio "g7" Paolantonio
  * SPDX-License-Identifier: GPL-3.0+
  * Author: Giuseppe Corti <giuseppe.corti@pm.me>
+ *         Erfan Abdi
+ *         Eugenio "g7" Paolantonio <me@medesimo.eu>
  */
 
-#define G_LOG_DOMAIN "fbd-dev-leds"
+#define G_LOG_DOMAIN "fbd-droid-leds"
 #define MAXIMUM_HYBRIS_LED_BRIGHTNESS		100
 
-#include "fbd.h"
-#include "fbd-enums.h"
 #include "fbd-droid-leds.h"
-#include "fbd-feedback-led.h"
+#include "fbd-binder.h"
+
+#include "fbd-droid-leds-backend.h"
+#include "fbd-droid-leds-backend-hidl.h"
 
 #include <gio/gio.h>
 
 #include <memory.h>
-#include <gbinder.h>
 
 /**
  * SECTION:fbd-droid-leds
@@ -25,100 +29,51 @@
  * #FbdDevLeds is used to interface with LEDS via gbinder.
  */
 
-#define BINDER_LIGHT_SERVICE_DEVICE "/dev/hwbinder"
-#define BINDER_LIGHT_SERVICE_IFACE "android.hardware.light@2.0::ILight"
-#define BINDER_LIGHT_SERVICE_SLOT "default"
-
 typedef struct _FbdDevLeds {
     GObject      parent;
 
-    GBinderServiceManager* sm;  
-    GBinderRemoteObject* remote;
-    GBinderClient* client;
-
+    FbdDroidLedsBackend *backend;
 } FbdDevLeds;
-
 
 static void initable_iface_init (GInitableIface *iface);
 
 G_DEFINE_TYPE_WITH_CODE (FbdDevLeds, fbd_dev_leds, G_TYPE_OBJECT,
                          G_IMPLEMENT_INTERFACE (G_TYPE_INITABLE, initable_iface_init));
 
+
 static gboolean
-initable_init (GInitable    *initable,
-               GCancellable *cancellable,
-               GError      **error)
+initable_init (GInitable     *initable,
+               GCancellable  *cancellable,
+               GError       **error)
 {
     FbdDevLeds *self = FBD_DEV_LEDS (initable);
-    char *fqname =
-        (BINDER_LIGHT_SERVICE_IFACE "/" BINDER_LIGHT_SERVICE_SLOT);
+    gboolean success;
 
     g_debug("initializing droid leds");
 
-    self->sm = gbinder_servicemanager_new(BINDER_LIGHT_SERVICE_DEVICE);
-    if (!self->sm) {
-        g_set_error (error,
-                     G_IO_ERROR, G_IO_ERROR_FAILED,
-                     "Failed to init servicemanager");
-        return FALSE;
-    }
-    self->remote = gbinder_servicemanager_get_service_sync(self->sm,
-        fqname, NULL);
-    if (!self->remote) {
-        g_set_error (error,
-                     G_IO_ERROR, G_IO_ERROR_FAILED,
-                     "Failed to get light hal service remote");
-        gbinder_servicemanager_unref(self->sm);
-        return FALSE;
-    }
-    self->client = gbinder_client_new(self->remote, BINDER_LIGHT_SERVICE_IFACE);
-    if (!self->client) {
-        g_set_error (error,
-                     G_IO_ERROR, G_IO_ERROR_FAILED,
-                     "Failed to get light hal service client");
-        gbinder_remote_object_unref(self->remote);
-        gbinder_servicemanager_unref(self->sm);
-        return FALSE;
-    }
+    self->backend = (FbdDroidLedsBackend *) fbd_droid_leds_backend_hidl_new (error);
 
-    GBinderLocalRequest* req = gbinder_client_new_request(self->client);
-    GBinderRemoteReply* reply;
-    int status;
+    if (!self->backend) {
 
-    reply = gbinder_client_transact_sync_reply(self->client,
-        2 /* getSupportedTypes */, req, &status);
-    gbinder_local_request_unref(req);
-
-    if (status == GBINDER_STATUS_OK) {
-        GBinderReader reader;
-        guint value;
-
-        gbinder_remote_reply_init_reader(reply, &reader);
-        status = gbinder_reader_read_uint32(&reader, &value);
-        if (value != GBINDER_STATUS_OK) {
             g_set_error (error,
                          G_IO_ERROR, G_IO_ERROR_FAILED,
-                         "Failed to get leds supported types");
+                         "Failed to obtain suitable light hal");
             return FALSE;
-        }
-        
-        gsize count = 0;
-        gsize vecSize = 0;
-        const int32_t *types;
-        types = gbinder_reader_read_hidl_vec(&reader, &count, &vecSize);
-        for (int i = 0; i < count; i++) {
-            if (types[i] == LIGHT_TYPE_NOTIFICATIONS) {
-                g_debug ("droid LED usable");
-                return TRUE;
-            }
-        }
     }
 
-    g_set_error (error,
-                 G_IO_ERROR, G_IO_ERROR_FAILED,
-                 "Failed to find notification led on light hal");
-    return FALSE;
+    success = fbd_droid_leds_backend_is_supported (self->backend);
+
+    if (!success) {
+        g_set_error (error,
+                     G_IO_ERROR, G_IO_ERROR_FAILED,
+                     "Failed to get supported LED types");
+        return FALSE;
+    }
+
+    g_debug ("Droid leds device usable");
+    return TRUE;
 }
+
 
 static void
 initable_iface_init (GInitableIface *iface)
@@ -126,16 +81,16 @@ initable_iface_init (GInitableIface *iface)
     iface->init = initable_init;
 }
 
+
 static void
 fbd_dev_leds_dispose (GObject *object)
 {
     FbdDevLeds *self = FBD_DEV_LEDS (object);
 
     g_debug("Disposing droid leds");
-    if (self->client)
-        gbinder_client_unref(self->client);
-    if (self->sm)
-        gbinder_servicemanager_unref(self->sm);
+
+    g_clear_object (&self->backend);
+
     G_OBJECT_CLASS (fbd_dev_leds_parent_class)->dispose (object);
 }
 
@@ -147,18 +102,20 @@ fbd_dev_leds_class_init (FbdDevLedsClass *klass)
     object_class->dispose = fbd_dev_leds_dispose;
 }
 
+
 static void
 fbd_dev_leds_init (FbdDevLeds *self)
 {
 }
 
+
 FbdDevLeds *
 fbd_dev_leds_new (GError **error)
 {
     return FBD_DEV_LEDS (g_initable_new (FBD_TYPE_DEV_LEDS,
-                                         NULL,
-                                         error,
-                                         NULL));
+                                          NULL,
+                                          error,
+                                          NULL));
 }
 
 /**
@@ -175,64 +132,9 @@ fbd_dev_leds_start_periodic (FbdDevLeds *self, FbdFeedbackLedColor color,
                              guint max_brightness, guint freq)
 {
     g_debug ("droid LED start flashing");
-    uint32_t max, argb_color;
-    int32_t t;
 
-    max = (max_brightness / 100.0) * 0xff;
-    t = 1000 * 1000 / freq / 2;
-
-    int alpha = 0xff; // Full Alpha
-    argb_color = (alpha & 0xff) << 24;
-    switch (color) {
-        case FBD_FEEDBACK_LED_COLOR_WHITE:
-            argb_color += ((max & 0xff) << 16) + ((max & 0xff) << 8) + (max & 0xff);
-            break;
-        case FBD_FEEDBACK_LED_COLOR_RED:
-            argb_color += (max & 0xff) << 16;
-            break;
-        case FBD_FEEDBACK_LED_COLOR_GREEN:
-            argb_color += (max & 0xff) << 8;
-            break;
-        case FBD_FEEDBACK_LED_COLOR_BLUE:
-            argb_color += max & 0xff;
-            break;
-    }
-
-    GBinderLocalRequest* req = gbinder_client_new_request(self->client);
-    GBinderRemoteReply* reply;
-    GBinderWriter writer;
-    LightState* notification_state;
-    int status;
-
-    gbinder_local_request_init_writer(req, &writer);
-    notification_state = gbinder_writer_new0(&writer, LightState);
-    notification_state->color = argb_color;
-    notification_state->flashMode = FLASH_TYPE_TIMED;
-    notification_state->flashOnMs = t;
-    notification_state->flashOffMs = t;
-    notification_state->brightnessMode = BRIGHTNESS_MODE_USER;
-
-    gbinder_writer_append_int32(&writer, LIGHT_TYPE_NOTIFICATIONS);
-    gbinder_writer_append_buffer_object(&writer, notification_state,
-            sizeof(*notification_state));
-
-    reply = gbinder_client_transact_sync_reply(self->client,
-        1 /* setLight */, req, &status);
-    gbinder_local_request_unref(req);
-
-    if (status == GBINDER_STATUS_OK) {
-        GBinderReader reader;
-        guint value;
-
-        gbinder_remote_reply_init_reader(reply, &reader);
-        status = gbinder_reader_read_uint32(&reader, &value);
-        if (value != GBINDER_STATUS_OK)
-            return FALSE;
-    } else {
-        return FALSE;
-    }
-
-    return TRUE;
+    return fbd_droid_leds_backend_start_periodic (self->backend, color,
+      max_brightness, freq);
 }
 
 gboolean
@@ -240,39 +142,6 @@ fbd_dev_leds_stop (FbdDevLeds *self, FbdFeedbackLedColor color)
 {
     g_debug ("droid LED stop flashing");
 
-    GBinderLocalRequest* req = gbinder_client_new_request(self->client);
-    GBinderRemoteReply* reply;
-    GBinderWriter writer;
-    LightState* notification_state;
-    int status;
-
-    gbinder_local_request_init_writer(req, &writer);
-    notification_state = gbinder_writer_new0(&writer, LightState);
-    notification_state->color = 0;
-    notification_state->flashMode = FLASH_TYPE_NONE;
-    notification_state->flashOnMs = 0;
-    notification_state->flashOffMs = 0;
-    notification_state->brightnessMode = BRIGHTNESS_MODE_USER;
-
-    gbinder_writer_append_int32(&writer, LIGHT_TYPE_NOTIFICATIONS);
-    gbinder_writer_append_buffer_object(&writer, notification_state,
-            sizeof(*notification_state));
-
-    reply = gbinder_client_transact_sync_reply(self->client,
-        1 /* setLight */, req, &status);
-    gbinder_local_request_unref(req);
-
-    if (status == GBINDER_STATUS_OK) {
-        GBinderReader reader;
-        guint value;
-
-        gbinder_remote_reply_init_reader(reply, &reader);
-        status = gbinder_reader_read_uint32(&reader, &value);
-        if (value != GBINDER_STATUS_OK)
-            return FALSE;
-    } else {
-        return FALSE;
-    }
-
-    return TRUE;
+    return fbd_droid_leds_backend_stop (self->backend, color);
 }
+

--- a/src/fbd-droid-leds.c
+++ b/src/fbd-droid-leds.c
@@ -16,6 +16,7 @@
 
 #include "fbd-droid-leds-backend.h"
 #include "fbd-droid-leds-backend-hidl.h"
+#include "fbd-droid-leds-backend-aidl.h"
 
 #include <gio/gio.h>
 
@@ -51,14 +52,19 @@ initable_init (GInitable     *initable,
 
     g_debug("initializing droid leds");
 
-    self->backend = (FbdDroidLedsBackend *) fbd_droid_leds_backend_hidl_new (error);
+    /* Try with AIDL first */
+    self->backend = (FbdDroidLedsBackend *) fbd_droid_leds_backend_aidl_new (error);
 
     if (!self->backend) {
+        /* No luck, try with HIDL */
+        self->backend = (FbdDroidLedsBackend *) fbd_droid_leds_backend_hidl_new (error);
 
+        if (!self->backend) {
             g_set_error (error,
                          G_IO_ERROR, G_IO_ERROR_FAILED,
                          "Failed to obtain suitable light hal");
             return FALSE;
+        }
     }
 
     success = fbd_droid_leds_backend_is_supported (self->backend);

--- a/src/fbd-droid-leds.h
+++ b/src/fbd-droid-leds.h
@@ -7,49 +7,14 @@
 
 #include "fbd-feedback-led.h"
 
-#include <stdint.h>
 #include <glib-object.h>
+#include <gudev/gudev.h>
 
 G_BEGIN_DECLS
 
-#define ALIGNED(x) __attribute__ ((aligned(x)))
-
-#define FBD_TYPE_DEV_LEDS (fbd_dev_leds_get_type ())
+#define FBD_TYPE_DEV_LEDS (fbd_dev_leds_get_type())
 
 G_DECLARE_FINAL_TYPE (FbdDevLeds, fbd_dev_leds, FBD, DEV_LEDS, GObject);
-
-enum {
-    LIGHT_TYPE_BACKLIGHT = 0,
-    LIGHT_TYPE_KEYBOARD = 1,
-    LIGHT_TYPE_BUTTONS = 2,
-    LIGHT_TYPE_BATTERY = 3,
-    LIGHT_TYPE_NOTIFICATIONS = 4,
-    LIGHT_TYPE_ATTENTION = 5,
-    LIGHT_TYPE_BLUETOOTH = 6,
-    LIGHT_TYPE_WIFI = 7,
-    LIGHT_TYPE_COUNT = 8,
-};
-
-enum {
-    FLASH_TYPE_NONE = 0,
-    FLASH_TYPE_TIMED = 1,
-    FLASH_TYPE_HARDWARE = 2,
-};
-
-enum {
-    BRIGHTNESS_MODE_USER = 0,
-    BRIGHTNESS_MODE_SENSOR = 1,
-    BRIGHTNESS_MODE_LOW_PERSISTENCE = 2,
-};
-
-typedef struct light_state {
-    uint32_t color ALIGNED(4);
-    int32_t flashMode ALIGNED(4);
-    int32_t flashOnMs ALIGNED(4);
-    int32_t flashOffMs ALIGNED(4);
-    int32_t brightnessMode ALIGNED(4);
-} ALIGNED(4) LightState;
-G_STATIC_ASSERT(sizeof(LightState) == 20);
 
 FbdDevLeds *fbd_dev_leds_new (GError **error);
 gboolean    fbd_dev_leds_start_periodic (FbdDevLeds *self,
@@ -57,5 +22,6 @@ gboolean    fbd_dev_leds_start_periodic (FbdDevLeds *self,
                                          guint max_brighness, guint freq);
 gboolean    fbd_dev_leds_stop (FbdDevLeds         *self,
                                FbdFeedbackLedColor color);
+
 
 G_END_DECLS

--- a/src/fbd-droid-vibra-backend-aidl.c
+++ b/src/fbd-droid-vibra-backend-aidl.c
@@ -1,0 +1,294 @@
+/*
+ * Copyright (C) 2022 Eugenio "g7" Paolantonio
+ * SPDX-License-Identifier: GPL-3.0+
+ * Author: Eugenio "g7" Paolantonio <me@medesimo.eu>
+ */
+
+#define G_LOG_DOMAIN "fbd-droid-vibra-backend-aidl"
+
+#include <stdlib.h>
+#include <glib.h>
+#include <glib-object.h>
+#include <gio/gio.h>
+#include <gbinder.h>
+
+#include "fbd-binder.h"
+#include "fbd-droid-vibra-backend.h"
+#include "fbd-droid-vibra-backend-aidl.h"
+
+
+#define BINDER_VIBRATOR_DEFAULT_AIDL_DEVICE "/dev/binder"
+
+#define BINDER_VIBRATOR_AIDL_IFACE "android.hardware.vibrator.IVibrator"
+#define BINDER_VIBRATOR_AIDL_CALLBACK_IFACE "android.hardware.vibrator.IVibratorCallback"
+#define BINDER_VIBRATOR_AIDL_SLOT "default"
+
+/* Methods */
+enum
+{
+  /* int getCapabilities(); */
+  BINDER_VIBRATOR_AIDL_GET_CAPABILITIES = 1,
+  /* void on(in int timeoutMs, in android.hardware.vibrator.IVibratorCallback callback); */
+  BINDER_VIBRATOR_AIDL_ON = 3,
+  /* void off(); */
+  BINDER_VIBRATOR_AIDL_OFF = 2,
+};
+
+/* Capabilities */
+typedef enum
+{
+  BINDER_VIBRATOR_AIDL_CAP_NONE = 0,
+  BINDER_VIBRATOR_AIDL_CAP_ON_CALLBACK = 1,
+  BINDER_VIBRATOR_AIDL_CAP_PERFORM_CALLBACK = 2,
+  BINDER_VIBRATOR_AIDL_CAP_AMPLITUDE_CONTROL = 4,
+  BINDER_VIBRATOR_AIDL_CAP_EXTERNAL_CONTROL = 8,
+  BINDER_VIBRATOR_AIDL_CAP_EXTERNAL_AMPLITUDE_CONTROL = 8,
+  BINDER_VIBRATOR_AIDL_CAP_COMPOSE_EFFECTS = 32,
+  BINDER_VIBRATOR_AIDL_CAP_ALWAYS_ON_CONTROL = 64,
+} FbdDroidVibraBackendAidlCapabilities;
+
+struct _FbdDroidVibraBackendAidl
+{
+  GObject parent_instance;
+
+  GBinderServiceManager *service_manager;
+  GBinderRemoteObject   *remote;
+  GBinderClient         *client;
+  
+  GBinderLocalObject    *callback_object;
+};
+
+static void initable_interface_init (GInitableIface *iface);
+static void fbd_droid_vibra_backend_interface_init (FbdDroidVibraBackendInterface *iface);
+
+G_DEFINE_TYPE_WITH_CODE (FbdDroidVibraBackendAidl, fbd_droid_vibra_backend_aidl, G_TYPE_OBJECT,
+                         G_IMPLEMENT_INTERFACE (G_TYPE_INITABLE, initable_interface_init)
+                         G_IMPLEMENT_INTERFACE (FBD_TYPE_DROID_VIBRA_BACKEND,
+                                                fbd_droid_vibra_backend_interface_init))
+
+static GBinderLocalReply *
+fbd_droid_vibra_backend_aidl_callback (GBinderLocalObject   *obj,
+                                       GBinderRemoteRequest *req,
+                                       guint                 code,
+                                       guint                 flags,
+                                       int                  *status,
+                                       void                 *user_data)
+{
+  /* Unused for now */
+
+  return NULL;
+}
+
+#if 0
+/* Unused for now, but could be useful in future to determine whether the
+ * underlying HAL supports callbacks at all.
+*/
+static FbdDroidVibraBackendAidlCapabilities
+fbd_droid_vibra_backend_get_capabilities (FbdDroidVibraBackend *backend)
+{
+  FbdDroidVibraBackendAidl *self = FBD_DROID_VIBRA_BACKEND_AIDL (backend);
+  GBinderLocalRequest *req = gbinder_client_new_request (self->client);
+  GBinderRemoteReply *reply;
+  GBinderReader reader;
+  int status;
+  int capabilities;
+
+  gbinder_local_request_append_int32 (req, BINDER_STABILITY_VENDOR); /* stability */
+
+  reply = gbinder_client_transact_sync_reply (self->client,
+                                              BINDER_VIBRATOR_AIDL_GET_CAPABILITIES,
+                                              req, &status);
+  gbinder_local_request_unref (req);
+  
+  gbinder_remote_reply_init_reader (reply, &reader);
+  
+  if (status == GBINDER_STATUS_OK && fbd_binder_status_is_ok (&reader) &&
+      gbinder_reader_read_int32 (&reader, &capabilities)) {
+    return (FbdDroidVibraBackendAidlCapabilities) capabilities;
+  } else {
+    g_warning ("Unable to get capabilities!");
+    return BINDER_VIBRATOR_AIDL_CAP_NONE;
+  }
+}
+#endif /* Unused */
+
+static gboolean
+fbd_droid_vibra_backend_aidl_on (FbdDroidVibraBackend *backend,
+                                 int                       duration)
+{
+  FbdDroidVibraBackendAidl *self = FBD_DROID_VIBRA_BACKEND_AIDL (backend);
+  GBinderLocalRequest *req = gbinder_client_new_request (self->client);
+  GBinderRemoteReply *reply;
+  int status;
+
+  gbinder_local_request_append_int32 (req, duration); /* duration */
+  gbinder_local_request_append_local_object (req, self->callback_object); /* callback */
+  gbinder_local_request_append_int32 (req, BINDER_STABILITY_VINTF); /* stability */
+
+  reply = gbinder_client_transact_sync_reply (self->client,
+                                              BINDER_VIBRATOR_AIDL_ON,
+                                              req, &status);
+  gbinder_local_request_unref (req);
+  
+  if (status == GBINDER_STATUS_OK && fbd_binder_reply_status_is_ok (reply)) {
+    return TRUE;
+  } else {
+    g_warning ("Unable to turn the vibrator on");
+    return FALSE;
+  }
+}
+
+static gboolean
+fbd_droid_vibra_backend_aidl_off (FbdDroidVibraBackend *backend)
+{
+  FbdDroidVibraBackendAidl *self = FBD_DROID_VIBRA_BACKEND_AIDL (backend);
+  GBinderLocalRequest *req = gbinder_client_new_request (self->client);
+  GBinderRemoteReply *reply;
+  int status;
+
+  gbinder_local_request_append_int32 (req, BINDER_STABILITY_VINTF); /* stability */
+
+  reply = gbinder_client_transact_sync_reply (self->client,
+                                              BINDER_VIBRATOR_AIDL_OFF,
+                                              req, &status);
+  gbinder_local_request_unref(req);
+  
+  if (status == GBINDER_STATUS_OK && fbd_binder_reply_status_is_ok (reply)) {
+    return TRUE;
+  } else {
+    g_warning ("Unable to turn the vibrator off");
+    return FALSE;
+  }
+}
+
+static gboolean
+initable_init (GInitable     *initable,
+               GCancellable  *cancellable,
+               GError       **error)
+{
+  FbdDroidVibraBackendAidl *self = FBD_DROID_VIBRA_BACKEND_AIDL (initable);
+  gboolean success;
+
+  g_debug ("Initializing droid vibra aidl");
+
+  success = fbd_binder_init (BINDER_VIBRATOR_DEFAULT_AIDL_DEVICE,
+                             BINDER_VIBRATOR_AIDL_IFACE,
+                             (BINDER_VIBRATOR_AIDL_IFACE "/" BINDER_VIBRATOR_AIDL_SLOT),
+                             &self->service_manager,
+                             &self->remote,
+                             &self->client);
+
+
+  if (!success) {
+    g_set_error (error,
+                 G_IO_ERROR, G_IO_ERROR_FAILED,
+                 "Failed to obtain suitable vibrator hal");
+    return FALSE;
+  }
+
+  self->callback_object =
+    gbinder_servicemanager_new_local_object (self->service_manager,
+                                             BINDER_VIBRATOR_AIDL_CALLBACK_IFACE,
+                                             fbd_droid_vibra_backend_aidl_callback,
+                                             self);
+
+  return TRUE;
+}
+
+static void
+fbd_droid_vibra_backend_aidl_constructed (GObject *obj)
+{
+  FbdDroidVibraBackendAidl *self = FBD_DROID_VIBRA_BACKEND_AIDL (obj);
+
+  G_OBJECT_CLASS (fbd_droid_vibra_backend_aidl_parent_class)->constructed (obj);
+
+  self->service_manager = NULL;
+  self->remote = NULL;
+  self->client = NULL;
+  self->callback_object = NULL;
+}
+
+static void
+fbd_droid_vibra_backend_aidl_dispose (GObject *obj)
+{
+  FbdDroidVibraBackendAidl *self = FBD_DROID_VIBRA_BACKEND_AIDL (obj);
+
+  g_debug ("Disposing droid vibra aidl");
+
+  if (self->callback_object) {
+    gbinder_local_object_unref (self->callback_object);
+  }
+
+  if (self->client) {
+    gbinder_client_unref (self->client);
+  }
+
+  if (self->remote) {
+    gbinder_remote_object_unref (self->remote);
+  }
+
+  if (self->service_manager) {
+    gbinder_servicemanager_unref (self->service_manager);
+  }
+
+  G_OBJECT_CLASS (fbd_droid_vibra_backend_aidl_parent_class)->dispose (obj);
+}
+
+static void
+fbd_droid_vibra_backend_aidl_set_property (GObject      *obj,
+                                           uint          property_id,
+                                           const GValue *value,
+                                           GParamSpec   *pspec)
+{
+  /* No properties supported yet */
+}
+
+static void
+fbd_droid_vibra_backend_aidl_get_property (GObject    *obj,
+                                           uint        property_id,
+                                           GValue     *value,
+                                           GParamSpec *pspec)
+{
+  /* No properties supported yet */
+  G_OBJECT_WARN_INVALID_PROPERTY_ID (obj, property_id, pspec);
+}
+
+
+static void
+fbd_droid_vibra_backend_aidl_class_init (FbdDroidVibraBackendAidlClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+  object_class->constructed  = fbd_droid_vibra_backend_aidl_constructed;
+  object_class->dispose      = fbd_droid_vibra_backend_aidl_dispose;
+  object_class->set_property = fbd_droid_vibra_backend_aidl_set_property;
+  object_class->get_property = fbd_droid_vibra_backend_aidl_get_property;
+}
+
+static void
+initable_interface_init (GInitableIface *iface)
+{
+  iface->init = initable_init;
+}
+
+static void
+fbd_droid_vibra_backend_interface_init (FbdDroidVibraBackendInterface *iface)
+{
+  iface->on  = fbd_droid_vibra_backend_aidl_on;
+  iface->off = fbd_droid_vibra_backend_aidl_off;
+}
+
+static void
+fbd_droid_vibra_backend_aidl_init (FbdDroidVibraBackendAidl *self)
+{
+}
+
+FbdDroidVibraBackendAidl *
+fbd_droid_vibra_backend_aidl_new (GError **error)
+{
+  return FBD_DROID_VIBRA_BACKEND_AIDL (
+    g_initable_new (FBD_TYPE_DROID_VIBRA_BACKEND_AIDL,
+                    NULL,
+                    error,
+                    NULL));
+}

--- a/src/fbd-droid-vibra-backend-aidl.h
+++ b/src/fbd-droid-vibra-backend-aidl.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2022 Eugenio "g7" Paolantonio
+ * SPDX-License-Identifier: GPL-3.0+
+ * Author: Eugenio "g7" Paolantonio <me@medesimo.eu>
+ */
+
+#pragma once
+
+#include <glib-object.h>
+
+G_BEGIN_DECLS
+
+#define FBD_TYPE_DROID_VIBRA_BACKEND_AIDL fbd_droid_vibra_backend_aidl_get_type ()
+G_DECLARE_FINAL_TYPE (FbdDroidVibraBackendAidl, fbd_droid_vibra_backend_aidl, FBD, DROID_VIBRA_BACKEND_AIDL, GObject)
+
+FbdDroidVibraBackendAidl *fbd_droid_vibra_backend_aidl_new (GError **error);
+
+G_END_DECLS

--- a/src/fbd-droid-vibra-backend-hidl.c
+++ b/src/fbd-droid-vibra-backend-hidl.c
@@ -1,0 +1,218 @@
+/*
+ * Copyright (C) 2021 Erfan Abdi
+ * Copyright (C) 2022 Eugenio "g7" Paolantonio
+ * SPDX-License-Identifier: GPL-3.0+
+ * Author: Erfan Abdi
+ *         Eugenio "g7" Paolantonio <me@medesimo.eu>
+ */
+
+#define G_LOG_DOMAIN "fbd-droid-vibra-backend-hidl"
+
+#include <stdlib.h>
+#include <glib.h>
+#include <glib-object.h>
+#include <gio/gio.h>
+#include <gbinder.h>
+
+#include "fbd-binder.h"
+#include "fbd-droid-vibra-backend.h"
+#include "fbd-droid-vibra-backend-hidl.h"
+
+#define BINDER_VIBRATOR_DEFAULT_HIDL_DEVICE "/dev/hwbinder"
+
+#define BINDER_VIBRATOR_HIDL_IFACE(v) "android.hardware.vibrator@" v "::IVibrator"
+#define BINDER_VIBRATOR_HIDL_SLOT "default"
+
+#define BINDER_VIBRATOR_HIDL_1_0_IFACE BINDER_VIBRATOR_HIDL_IFACE("1.0")
+
+/* Methods */
+enum
+{
+  /* on(uint32_t timeoutMs) generates (Status vibratorOnRet); */
+  BINDER_VIBRATOR_HIDL_1_0_ON = 1,
+  /* off() generates (Status vibratorOffRet); */
+  BINDER_VIBRATOR_HIDL_1_0_OFF = 2,
+};
+
+struct _FbdDroidVibraBackendHidl
+{
+  GObject parent_instance;
+
+  GBinderServiceManager *service_manager;
+  GBinderRemoteObject   *remote;
+  GBinderClient         *client;
+};
+
+static void initable_interface_init (GInitableIface *iface);
+static void fbd_droid_vibra_backend_interface_init (FbdDroidVibraBackendInterface *iface);
+
+G_DEFINE_TYPE_WITH_CODE (FbdDroidVibraBackendHidl, fbd_droid_vibra_backend_hidl, G_TYPE_OBJECT,
+                         G_IMPLEMENT_INTERFACE (G_TYPE_INITABLE, initable_interface_init)
+                         G_IMPLEMENT_INTERFACE (FBD_TYPE_DROID_VIBRA_BACKEND,
+                                                fbd_droid_vibra_backend_interface_init))
+
+static gboolean
+fbd_droid_vibra_backend_hidl_on (FbdDroidVibraBackend *backend,
+                                 int                       duration)
+{
+  FbdDroidVibraBackendHidl *self = FBD_DROID_VIBRA_BACKEND_HIDL (backend);
+  GBinderLocalRequest *req = gbinder_client_new_request (self->client);
+  GBinderRemoteReply *reply;
+  int status;
+
+  gbinder_local_request_append_int32 (req, duration); /* duration */
+
+  reply = gbinder_client_transact_sync_reply (self->client,
+                                              BINDER_VIBRATOR_HIDL_1_0_ON,
+                                              req, &status);
+  gbinder_local_request_unref (req);
+  
+  if (status == GBINDER_STATUS_OK && fbd_binder_reply_status_is_ok (reply)) {
+    return TRUE;
+  } else {
+    g_warning ("Unable to turn the vibrator on");
+    return FALSE;
+  }
+}
+
+static gboolean
+fbd_droid_vibra_backend_hidl_off (FbdDroidVibraBackend *backend)
+{
+  FbdDroidVibraBackendHidl *self = FBD_DROID_VIBRA_BACKEND_HIDL (backend);
+  GBinderLocalRequest *req = gbinder_client_new_request (self->client);
+  GBinderRemoteReply *reply;
+  int status;
+
+  reply = gbinder_client_transact_sync_reply (self->client,
+                                              BINDER_VIBRATOR_HIDL_1_0_OFF,
+                                              req, &status);
+  gbinder_local_request_unref(req);
+  
+  if (status == GBINDER_STATUS_OK && fbd_binder_reply_status_is_ok (reply)) {
+    return TRUE;
+  } else {
+    g_warning ("Unable to turn the vibrator off");
+    return FALSE;
+  }
+}
+
+static gboolean
+initable_init (GInitable     *initable,
+               GCancellable  *cancellable,
+               GError       **error)
+{
+  FbdDroidVibraBackendHidl *self = FBD_DROID_VIBRA_BACKEND_HIDL (initable);
+  gboolean success;
+
+  g_debug ("Initializing droid vibra hidl");
+
+  success = fbd_binder_init (BINDER_VIBRATOR_DEFAULT_HIDL_DEVICE,
+                             BINDER_VIBRATOR_HIDL_1_0_IFACE,
+                             (BINDER_VIBRATOR_HIDL_1_0_IFACE "/" BINDER_VIBRATOR_HIDL_SLOT),
+                             &self->service_manager,
+                             &self->remote,
+                             &self->client);
+
+
+  if (!success) {
+    g_set_error (error,
+                 G_IO_ERROR, G_IO_ERROR_FAILED,
+                 "Failed to obtain suitable vibrator hal");
+    return FALSE;
+  }
+
+  return TRUE;
+}
+
+static void
+fbd_droid_vibra_backend_hidl_constructed (GObject *obj)
+{
+  FbdDroidVibraBackendHidl *self = FBD_DROID_VIBRA_BACKEND_HIDL (obj);
+
+  G_OBJECT_CLASS (fbd_droid_vibra_backend_hidl_parent_class)->constructed (obj);
+
+  self->service_manager = NULL;
+  self->remote = NULL;
+  self->client = NULL;
+}
+
+static void
+fbd_droid_vibra_backend_hidl_dispose (GObject *obj)
+{
+  FbdDroidVibraBackendHidl *self = FBD_DROID_VIBRA_BACKEND_HIDL (obj);
+
+  g_debug ("Disposing droid vibra hidl");
+
+  if (self->client) {
+    gbinder_client_unref (self->client);
+  }
+  
+  if (self->remote) {
+    gbinder_remote_object_unref (self->remote);
+  }
+  
+  if (self->service_manager) {
+    gbinder_servicemanager_unref (self->service_manager);
+  }
+
+  G_OBJECT_CLASS (fbd_droid_vibra_backend_hidl_parent_class)->dispose (obj);
+}
+
+static void
+fbd_droid_vibra_backend_hidl_set_property (GObject      *obj,
+                                           uint          property_id,
+                                           const GValue *value,
+                                           GParamSpec   *pspec)
+{
+  /* No properties supported yet */
+}
+
+static void
+fbd_droid_vibra_backend_hidl_get_property (GObject    *obj,
+                                           uint        property_id,
+                                           GValue     *value,
+                                           GParamSpec *pspec)
+{
+  /* No properties supported yet */
+  G_OBJECT_WARN_INVALID_PROPERTY_ID (obj, property_id, pspec);
+}
+
+
+static void
+fbd_droid_vibra_backend_hidl_class_init (FbdDroidVibraBackendHidlClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+  object_class->constructed  = fbd_droid_vibra_backend_hidl_constructed;
+  object_class->dispose      = fbd_droid_vibra_backend_hidl_dispose;
+  object_class->set_property = fbd_droid_vibra_backend_hidl_set_property;
+  object_class->get_property = fbd_droid_vibra_backend_hidl_get_property;
+}
+
+static void
+initable_interface_init (GInitableIface *iface)
+{
+  iface->init = initable_init;
+}
+
+static void
+fbd_droid_vibra_backend_interface_init (FbdDroidVibraBackendInterface *iface)
+{
+  iface->on  = fbd_droid_vibra_backend_hidl_on;
+  iface->off = fbd_droid_vibra_backend_hidl_off;
+}
+
+static void
+fbd_droid_vibra_backend_hidl_init (FbdDroidVibraBackendHidl *self)
+{
+}
+
+FbdDroidVibraBackendHidl *
+fbd_droid_vibra_backend_hidl_new (GError **error)
+{
+  return FBD_DROID_VIBRA_BACKEND_HIDL (
+    g_initable_new (FBD_TYPE_DROID_VIBRA_BACKEND_HIDL,
+                    NULL,
+                    error,
+                    NULL));
+}

--- a/src/fbd-droid-vibra-backend-hidl.h
+++ b/src/fbd-droid-vibra-backend-hidl.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2022 Eugenio "g7" Paolantonio
+ * SPDX-License-Identifier: GPL-3.0+
+ * Author: Eugenio "g7" Paolantonio <me@medesimo.eu>
+ */
+
+#pragma once
+
+#include <glib-object.h>
+
+G_BEGIN_DECLS
+
+#define FBD_TYPE_DROID_VIBRA_BACKEND_HIDL fbd_droid_vibra_backend_hidl_get_type ()
+G_DECLARE_FINAL_TYPE (FbdDroidVibraBackendHidl, fbd_droid_vibra_backend_hidl, FBD, DROID_VIBRA_BACKEND_HIDL, GObject)
+
+FbdDroidVibraBackendHidl *fbd_droid_vibra_backend_hidl_new (GError **error);
+
+G_END_DECLS

--- a/src/fbd-droid-vibra-backend.c
+++ b/src/fbd-droid-vibra-backend.c
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2022 Eugenio "g7" Paolantonio
+ * SPDX-License-Identifier: GPL-3.0+
+ * Author: Eugenio "g7" Paolantonio <me@medesimo.eu>
+ */
+
+#define G_LOG_DOMAIN "fbd-droid-vibra-backend"
+
+#include "fbd-droid-vibra-backend.h"
+
+G_DEFINE_INTERFACE (FbdDroidVibraBackend, fbd_droid_vibra_backend, G_TYPE_OBJECT)
+
+static void
+fbd_droid_vibra_backend_default_init (FbdDroidVibraBackendInterface *iface)
+{
+    /* Nothing yet */
+}
+
+gboolean
+fbd_droid_vibra_backend_on (FbdDroidVibraBackend *self,
+                            int                   duration)
+{
+  FbdDroidVibraBackendInterface *iface;
+  
+  g_return_val_if_fail (FBD_IS_DROID_VIBRA_BACKEND (self), FALSE);
+  
+  iface = FBD_DROID_VIBRA_BACKEND_GET_IFACE (self);
+  g_return_val_if_fail (iface->on != NULL, FALSE);
+  return iface->on (self, duration);
+}
+
+gboolean
+fbd_droid_vibra_backend_off (FbdDroidVibraBackend *self)
+{
+  FbdDroidVibraBackendInterface *iface;
+  
+  g_return_val_if_fail (FBD_IS_DROID_VIBRA_BACKEND (self), FALSE);
+  
+  iface = FBD_DROID_VIBRA_BACKEND_GET_IFACE (self);
+  g_return_val_if_fail (iface->off != NULL, FALSE);
+  return iface->off (self);
+}

--- a/src/fbd-droid-vibra-backend.h
+++ b/src/fbd-droid-vibra-backend.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2022 Eugenio "g7" Paolantonio
+ * SPDX-License-Identifier: GPL-3.0+
+ * Author: Eugenio "g7" Paolantonio <me@medesimo.eu>
+ */
+
+#pragma once
+
+#include <glib-object.h>
+
+G_BEGIN_DECLS
+
+#define FBD_TYPE_DROID_VIBRA_BACKEND fbd_droid_vibra_backend_get_type()
+G_DECLARE_INTERFACE (FbdDroidVibraBackend, fbd_droid_vibra_backend, FBD, DROID_VIBRA_BACKEND, GObject)
+
+struct _FbdDroidVibraBackendInterface
+{
+  GTypeInterface parent_iface;
+
+  gboolean (*on)  (FbdDroidVibraBackend *self,
+                   int                   duration);
+  gboolean (*off) (FbdDroidVibraBackend *self);
+};
+
+gboolean fbd_droid_vibra_backend_on  (FbdDroidVibraBackend *self,
+                                      int                   duration);
+gboolean fbd_droid_vibra_backend_off (FbdDroidVibraBackend  *self);
+
+G_END_DECLS

--- a/src/fbd-droid-vibra.c
+++ b/src/fbd-droid-vibra.c
@@ -15,6 +15,7 @@
 
 #include "fbd-droid-vibra-backend.h"
 #include "fbd-droid-vibra-backend-hidl.h"
+#include "fbd-droid-vibra-backend-aidl.h"
 
 #include <gio/gio.h>
 
@@ -103,14 +104,19 @@ initable_init (GInitable     *initable,
 
     g_debug("initializing droid vibra");
 
-    self->backend = (FbdDroidVibraBackend *) fbd_droid_vibra_backend_hidl_new (error);
+    /* Try with AIDL first */
+    self->backend = (FbdDroidVibraBackend *) fbd_droid_vibra_backend_aidl_new (error);
 
     if (!self->backend) {
+        /* No luck, try with HIDL */
+        self->backend = (FbdDroidVibraBackend *) fbd_droid_vibra_backend_hidl_new (error);
 
+        if (!self->backend) {
             g_set_error (error,
                          G_IO_ERROR, G_IO_ERROR_FAILED,
                          "Failed to obtain suitable vibrator hal");
             return FALSE;
+        }
     }
 
     g_debug ("Droid vibra device usable");

--- a/src/fbd-droid-vibra.c
+++ b/src/fbd-droid-vibra.c
@@ -1,12 +1,20 @@
 /*
  * Copyright (C) 2021 Giuseppe Corti
+ * Copyright (C) 2021 Erfan Abdi
+ * Copyright (C) 2022 Eugenio "g7" Paolantonio
  * SPDX-License-Identifier: GPL-3.0+
  * Author: Giuseppe Corti <giuseppe.corti@pm.me>
+ *         Erfan Abdi
+ *         Eugenio "g7" Paolantonio <me@medesimo.eu>
  */
 
 #define G_LOG_DOMAIN "fbd-droid-vibra"
 
 #include "fbd-droid-vibra.h"
+#include "fbd-binder.h"
+
+#include "fbd-droid-vibra-backend.h"
+#include "fbd-droid-vibra-backend-hidl.h"
 
 #include <gio/gio.h>
 
@@ -14,8 +22,6 @@
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <sys/types.h>
-
-#include <gbinder.h>
 
 /**
  * SECTION:fbd-droid-vibra
@@ -25,10 +31,6 @@
  * The #FbdDevVibra is used to interface with haptic motor via the force
  * feedback interface. It currently only supports one id at a time.
  */
-
-#define BINDER_VIBRATOR_SERVICE_DEVICE "/dev/hwbinder"
-#define BINDER_VIBRATOR_SERVICE_IFACE "android.hardware.vibrator@1.0::IVibrator"
-#define BINDER_VIBRATOR_SERVICE_SLOT "default"
 
 enum {
     PROP_0,
@@ -48,11 +50,7 @@ typedef struct _FbdDevVibra {
 
     GUdevDevice *device;
 
-    GBinderServiceManager* sm;  
-    GBinderRemoteObject* remote;
-    GBinderClient* client;
-
-    FbdDevVibraFeatureFlags features;
+    FbdDroidVibraBackend *backend;
 } FbdDevVibra;
 
 static void initable_iface_init (GInitableIface *iface);
@@ -100,35 +98,19 @@ initable_init (GInitable     *initable,
                GError       **error)
 {
     FbdDevVibra *self = FBD_DEV_VIBRA (initable);
-    char *fqname =
-        (BINDER_VIBRATOR_SERVICE_IFACE "/" BINDER_VIBRATOR_SERVICE_SLOT);
+    char *device, *iface, *fqname;
+    int i;
 
     g_debug("initializing droid vibra");
 
-    self->sm = gbinder_servicemanager_new(BINDER_VIBRATOR_SERVICE_DEVICE);
-    if (!self->sm) {
-        g_set_error (error,
-                     G_IO_ERROR, G_IO_ERROR_FAILED,
-                     "Failed to init servicemanager");
-        return FALSE;
-    }
-    self->remote = gbinder_servicemanager_get_service_sync(self->sm,
-        fqname, NULL);
-    if (!self->remote) {
-        g_set_error (error,
-                     G_IO_ERROR, G_IO_ERROR_FAILED,
-                     "Failed to get vibrator hal service remote");
-        gbinder_servicemanager_unref(self->sm);
-        return FALSE;
-    }
-    self->client = gbinder_client_new(self->remote, BINDER_VIBRATOR_SERVICE_IFACE);
-    if (!self->client) {
-        g_set_error (error,
-                     G_IO_ERROR, G_IO_ERROR_FAILED,
-                     "Failed to get vibrator hal service client");
-        gbinder_remote_object_unref(self->remote);
-        gbinder_servicemanager_unref(self->sm);
-        return FALSE;
+    self->backend = (FbdDroidVibraBackend *) fbd_droid_vibra_backend_hidl_new (error);
+
+    if (!self->backend) {
+
+            g_set_error (error,
+                         G_IO_ERROR, G_IO_ERROR_FAILED,
+                         "Failed to obtain suitable vibrator hal");
+            return FALSE;
     }
 
     g_debug ("Droid vibra device usable");
@@ -148,7 +130,10 @@ fbd_dev_vibra_dispose (GObject *object)
 {
     FbdDevVibra *self = FBD_DEV_VIBRA (object);
 
+    g_debug("Disposing droid vibra");
+
     g_clear_object (&self->device);
+    g_clear_object (&self->backend);
 
     G_OBJECT_CLASS (fbd_dev_vibra_parent_class)->dispose (object);
 }
@@ -159,11 +144,6 @@ fbd_dev_vibra_finalize (GObject *object)
 {
     FbdDevVibra *self = FBD_DEV_VIBRA (object);
 
-    g_debug("Finalizing droid vibra");
-    if (self->client)
-        gbinder_client_unref(self->client);
-    if (self->sm)
-        gbinder_servicemanager_unref(self->sm);
     G_OBJECT_CLASS (fbd_dev_vibra_parent_class)->finalize (object);
 }
 
@@ -206,35 +186,14 @@ fbd_dev_vibra_new (GUdevDevice *device, GError **error)
                                           NULL));
 }
 
-
 gboolean
 fbd_dev_vibra_rumble (FbdDevVibra *self, guint duration, gboolean upload)
 {
     g_return_val_if_fail (FBD_IS_DEV_VIBRA (self), FALSE);
 
     g_debug("Playing rumbling vibra effect");
-    GBinderLocalRequest* req = gbinder_client_new_request(self->client);
-    GBinderRemoteReply* reply;
-    int status;
 
-    gbinder_local_request_append_int32(req, duration);
-    reply = gbinder_client_transact_sync_reply(self->client,
-        1 /* on */, req, &status);
-    gbinder_local_request_unref(req);
-
-    if (status == GBINDER_STATUS_OK) {
-        GBinderReader reader;
-        guint value;
-
-        gbinder_remote_reply_init_reader(reply, &reader);
-        status = gbinder_reader_read_uint32(&reader, &value);
-        if (value != GBINDER_STATUS_OK)
-            return FALSE;
-    } else {
-        return FALSE;
-    }
-
-    return TRUE;
+    return fbd_droid_vibra_backend_on (self->backend, duration);
 }
 
 
@@ -244,28 +203,8 @@ fbd_dev_vibra_periodic (FbdDevVibra *self, guint duration, guint magnitude, guin
     g_return_val_if_fail (FBD_IS_DEV_VIBRA (self), FALSE);
 
     g_debug("Playing periodic vibra effect");
-    GBinderLocalRequest* req = gbinder_client_new_request(self->client);
-    GBinderRemoteReply* reply;
-    int status;
 
-    gbinder_local_request_append_int32(req, duration);
-    reply = gbinder_client_transact_sync_reply(self->client,
-        1 /* on */, req, &status);
-    gbinder_local_request_unref(req);
-
-    if (status == GBINDER_STATUS_OK) {
-        GBinderReader reader;
-        guint value;
-
-        gbinder_remote_reply_init_reader(reply, &reader);
-        status = gbinder_reader_read_uint32(&reader, &value);
-        if (value != GBINDER_STATUS_OK)
-            return FALSE;
-    } else {
-        return FALSE;
-    }
-
-    return TRUE;
+    return fbd_droid_vibra_backend_on (self->backend, duration);
 }
 
 
@@ -275,27 +214,8 @@ fbd_dev_vibra_remove_effect (FbdDevVibra *self)
     g_return_val_if_fail (FBD_IS_DEV_VIBRA (self), FALSE);
 
     g_debug("Erasing vibra effect");
-    GBinderLocalRequest* req = gbinder_client_new_request(self->client);
-    GBinderRemoteReply* reply;
-    int status;
 
-    reply = gbinder_client_transact_sync_reply(self->client,
-        2 /* off */, req, &status);
-    gbinder_local_request_unref(req);
-
-    if (status == GBINDER_STATUS_OK) {
-        GBinderReader reader;
-        guint value;
-
-        gbinder_remote_reply_init_reader(reply, &reader);
-        status = gbinder_reader_read_uint32(&reader, &value);
-        if (value != GBINDER_STATUS_OK)
-            return FALSE;
-    } else {
-        return FALSE;
-    }
-
-    return TRUE;
+    return fbd_droid_vibra_backend_off (self->backend);
 }
 
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -15,6 +15,7 @@ sources = [
   'fbd.c',
   'fbd-binder.c',
   'fbd-droid-vibra-backend.c',
+  'fbd-droid-vibra-backend-hidl.c',
   'fbd-droid-vibra.c',
   'fbd-droid-leds-backend.c',
   'fbd-droid-leds-backend-hidl.c',

--- a/src/meson.build
+++ b/src/meson.build
@@ -16,6 +16,7 @@ sources = [
   'fbd-binder.c',
   'fbd-droid-vibra-backend.c',
   'fbd-droid-vibra-backend-hidl.c',
+  'fbd-droid-vibra-backend-aidl.c',
   'fbd-droid-vibra.c',
   'fbd-droid-leds-backend.c',
   'fbd-droid-leds-backend-hidl.c',

--- a/src/meson.build
+++ b/src/meson.build
@@ -15,6 +15,7 @@ sources = [
   'fbd.c',
   'fbd-binder.c',
   'fbd-droid-vibra.c',
+  'fbd-droid-leds-backend.c',
   'fbd-droid-leds.c',
   'fbd-dev-vibra.c',
   'fbd-dev-sound.c',

--- a/src/meson.build
+++ b/src/meson.build
@@ -13,6 +13,7 @@ sources = [
   generated_dbus_sources,
   fbd_enum_sources,
   'fbd.c',
+  'fbd-binder.c',
   'fbd-droid-vibra.c',
   'fbd-droid-leds.c',
   'fbd-dev-vibra.c',

--- a/src/meson.build
+++ b/src/meson.build
@@ -19,6 +19,7 @@ sources = [
   'fbd-droid-vibra.c',
   'fbd-droid-leds-backend.c',
   'fbd-droid-leds-backend-hidl.c',
+  'fbd-droid-leds-backend-aidl.c',
   'fbd-droid-leds.c',
   'fbd-dev-vibra.c',
   'fbd-dev-sound.c',

--- a/src/meson.build
+++ b/src/meson.build
@@ -16,6 +16,7 @@ sources = [
   'fbd-binder.c',
   'fbd-droid-vibra.c',
   'fbd-droid-leds-backend.c',
+  'fbd-droid-leds-backend-hidl.c',
   'fbd-droid-leds.c',
   'fbd-dev-vibra.c',
   'fbd-dev-sound.c',

--- a/src/meson.build
+++ b/src/meson.build
@@ -14,6 +14,7 @@ sources = [
   fbd_enum_sources,
   'fbd.c',
   'fbd-binder.c',
+  'fbd-droid-vibra-backend.c',
   'fbd-droid-vibra.c',
   'fbd-droid-leds-backend.c',
   'fbd-droid-leds-backend-hidl.c',


### PR DESCRIPTION
This Pull Request adds two new interfaces, FbdDroidLedsBackend and FbdDroidVibraBackend. These interfaces can be used to implement multiple backends for both the leds and vibra HALs.

Alongside the new interfaces, the old HIDL-related code has been moved to FbdDroid{Leds,Vibra}BackendHidl, and AIDL HALs are now supported as well via the new FbdDroid{Leds,Vibra}BackendAidl.

Tested-ok on qx1000 (api28, hidl)
Tested-ok on bahamut (api30, aidl)